### PR TITLE
Update install-appdynamics.sh

### DIFF
--- a/rest/install-appdynamics.sh
+++ b/rest/install-appdynamics.sh
@@ -86,9 +86,11 @@ downloadInstallers() {
          ${APPD_LOGIN_URL} 
 
     SSO_SESSIONID=`grep "sso-sessionid" ${APPD_TEMP_DIR}/cookies.txt`
-    if [ ! "$SSO_SESSIONID" ]; then
-      echo "Incorrect Login/Password"
-      exit
+    # There is an issue with sso-sessionid, not a string available under cookies.txt
+    # hence the if condition is disabled temporary fix.
+    #if [ ! "$SSO_SESSIONID" ]; then
+      #echo "Incorrect Login/Password"
+      #exit
     fi
 
     for i in ${!APPD_AGENTS[@]}; do


### PR DESCRIPTION
docker compose file fails to install app agents with "invalid login/password" with correct
credentials 
Following IF condition disabled as a temporary fix, refer reason below
###########################################
    if [ ! "$SSO_SESSIONID" ]; then
      echo "Incorrect Login/Password"
      exit
 #########################################



While sso-sessionid is not a string available under cookies.txt and thus we are failing. If you will only run wget then it would go as success. Even if we use --keep-session-cookies we would add JSESSIONID but not sso-sessionid. Workaround for now would be to remove/alter the if condition mentioned.